### PR TITLE
Track globalize_serialized_attributes per class and not globally

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -83,7 +83,7 @@ module Globalize
   end
 end
 
-ActiveRecord::Base.mattr_accessor :globalize_serialized_attributes, instance_writer: false
+ActiveRecord::Base.class_attribute :globalize_serialized_attributes, instance_writer: false
 ActiveRecord::Base.globalize_serialized_attributes = {}
 
 ActiveRecord::Base.extend(Globalize::ActiveRecord::ActMacro)

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -15,6 +15,7 @@ module ActiveRecord
                     Coders::YAMLColumn.new(class_name_or_coder)
                   end
 
+          self.globalize_serialized_attributes = globalize_serialized_attributes.dup
           self.globalize_serialized_attributes[attr_name] = coder
         end
         alias_method_chain :serialize, :globalize

--- a/test/data/models/serialized_attr.rb
+++ b/test/data/models/serialized_attr.rb
@@ -2,3 +2,12 @@ class SerializedAttr < ActiveRecord::Base
   serialize :meta
   translates :meta
 end
+
+class JSONSerializedAttr < SerializedAttr
+  serialize :meta, JSON
+  translates :meta
+end
+
+class UnserializedAttr < ActiveRecord::Base
+  self.table_name = 'serialized_attrs'
+end

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -189,6 +189,12 @@ class AttributesTest < MiniTest::Spec
   end
 
   describe 'serializable attribute' do
+    it 'keeps track of serialized attributes between classes' do
+      assert_equal UnserializedAttr.globalize_serialized_attributes, {}
+      assert_equal SerializedAttr.globalize_serialized_attributes[:meta].class, ActiveRecord::Coders::YAMLColumn
+      assert_equal JSONSerializedAttr.globalize_serialized_attributes[:meta], ActiveRecord::Coders::JSON
+    end
+
     it 'works with default marshalling, without data' do
       model = SerializedAttr.create
       assert_equal nil, model.meta


### PR DESCRIPTION
mattr_accessor doesn't work well with subclasses so class_attribute is used instead.
class_attribute doesn't work well with mutable objects so a new hash is set when hash is modifier.

Fixes #472.
